### PR TITLE
Modal: improve animation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ watch:
 
 .PHONY: css
 css:
+	$(SASS) examples/css/styles.scss examples/css/styles.min.css
 	$(SASS) --watch examples/css/styles.scss examples/css/styles.min.css
 
 .PHONY: serve

--- a/components/modal/Modal.scss
+++ b/components/modal/Modal.scss
@@ -7,7 +7,7 @@ $border-color: #e5e5e5;
 
 
 
-.Modal-overlay.Modal-overlay--visible, .Modal.Modal--visible {
+.Modal-overlay.is-visible, .Modal.is-visible {
   opacity: 1;
   pointer-events: initial;
 }

--- a/components/modal/Modal.scss
+++ b/components/modal/Modal.scss
@@ -7,6 +7,10 @@ $border-color: #e5e5e5;
 
 
 
+.Modal-overlay.Modal-overlay--visible, .Modal.Modal--visible {
+  opacity: 1;
+  pointer-events: initial;
+}
 
 /**
  * Styles
@@ -23,9 +27,14 @@ $border-color: #e5e5e5;
   align-items: center;
   overflow: hidden;
   z-index: 100;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.5s ease;
 }
 
 .Modal {
+  pointer-events: none;
+  opacity: 0;
   position: relative;
   margin: 0 10px;
   width: 100vw;
@@ -35,6 +44,7 @@ $border-color: #e5e5e5;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
   border: 1px solid $border-color;
   border-radius: 2px;
+  transition: opacity 0.3s ease;
 
   @include medium {
     margin: 0;

--- a/components/modal/Modal.scss
+++ b/components/modal/Modal.scss
@@ -26,7 +26,7 @@ $border-color: #e5e5e5;
   justify-content: center;
   align-items: center;
   overflow: hidden;
-  z-index: 100;
+  z-index: 104;
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.5s ease;

--- a/components/modal/index.js
+++ b/components/modal/index.js
@@ -1,48 +1,35 @@
 
 import React from 'react'
+import classNames from 'classnames'
 import {Motion, spring} from 'react-motion'
 
 /**
  * Modal component
  */
 var Modal = ({header, body, footer, visible, toggle}) => (
-  <Motion defaultStyle={{opacity: 0, scale: 0}} style={{
-    opacity: visible ? spring(1) : 0,
-    scale: visible ? spring(1) : 0
-  }}>
-    {style =>
-      visible &&
-        <div
-          className='Modal-overlay'
-          onClick={() => toggle(false)}
-          onTouchEnd={() => toggle(false)}
-          style={{
-            opacity: style.opacity
-          }}
-        >
-          <div
-            className='Modal'
-            onClick={(e) => e.stopPropagation()}
-            onTouchEnd={(e) => e.stopPropagation()}
-            style={{
-              transform: `scale(${style.scale})`
-            }}
-          >
-            <div className='Modal-content'>
-              <div className='Modal-header'>
-                {header}
-              </div>
-              <div className='Modal-body'>
-                {body}
-              </div>
-            </div>
-            <div className='Modal-footer'>
-              {footer}
-            </div>
-          </div>
+  <div
+    className={classNames('Modal-overlay', {'Modal-overlay--visible': visible})}
+    onClick={() => toggle(false)}
+    onTouchEnd={() => toggle(false)}
+  >
+    <div
+      className={classNames('Modal', {'Modal--visible': visible})}
+      onClick={(e) => e.stopPropagation()}
+      onTouchEnd={(e) => e.stopPropagation()}
+    >
+      <div className='Modal-content'>
+        <div className='Modal-header'>
+          {header}
         </div>
-    }
-  </Motion>
+        <div className='Modal-body'>
+          {body}
+        </div>
+      </div>
+      <div className='Modal-footer'>
+        {footer}
+      </div>
+    </div>
+  </div>
 )
 
 Modal.propTypes = {

--- a/components/modal/index.js
+++ b/components/modal/index.js
@@ -1,7 +1,6 @@
 
 import React from 'react'
 import classNames from 'classnames'
-import {Motion, spring} from 'react-motion'
 
 /**
  * Modal component

--- a/components/modal/index.js
+++ b/components/modal/index.js
@@ -7,12 +7,12 @@ import classNames from 'classnames'
  */
 var Modal = ({header, body, footer, visible, toggle}) => (
   <div
-    className={classNames('Modal-overlay', {'Modal-overlay--visible': visible})}
+    className={classNames('Modal-overlay', {'is-visible': visible})}
     onClick={() => toggle(false)}
     onTouchEnd={() => toggle(false)}
   >
     <div
-      className={classNames('Modal', {'Modal--visible': visible})}
+      className={classNames('Modal', {'is-visible': visible})}
       onClick={(e) => e.stopPropagation()}
       onTouchEnd={(e) => e.stopPropagation()}
     >

--- a/components/modal/test/test.js
+++ b/components/modal/test/test.js
@@ -13,7 +13,8 @@ describe('Modal', () => {
 
   it('should be hidden by default', () => {
     const wrapper = mount(<Modal />)
-    assert.equal(wrapper.find('.Modal').length, 0)
+    assert.equal(wrapper.find('.Modal').length, 1)
+    assert.equal(wrapper.find('.Modal--visible').length, 0)
   })
 
   it('should callback when clicking on dark background', (done) => {


### PR DESCRIPTION
- Remove scale effect (no such effect on android)
- Just use opacity
- Just CSS / no Motion & Spring lib dep
- Modal stays in the DOM even if not visible.

See also here:
https://www.youtube.com/watch?v=jbU5yRhSbKg
http://stackoverflow.com/questions/30507642/how-should-a-material-design-dialog-box-be-animated