### PR TITLE
add google analytics

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -15,5 +15,15 @@
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.18.2/codemirror.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.18.2/mode/javascript/javascript.min.js"></script>
     <script src="js/script.min.js"></script>
+    <script>
+      if (window.location && window.location.host === 'hbm.github.io') {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-42875905-6', 'auto');
+      ga('send', 'pageview');
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
closes #109 

using my private gmail account. GA email invitations for fahri and mirco sent via email (gmail).

only tracking when hosted by hbm.github.io