### PR TITLE
Make Textarea component compatible with Inferno

### DIFF
--- a/src/components/textfield/index.js
+++ b/src/components/textfield/index.js
@@ -116,8 +116,8 @@ export class Textarea extends React.Component {
     }
   }
 
-  handleChange = (event) => {
-    this.props.onChange(event)
+  handleInput = (event) => {
+    this.props.onInput && this.props.onInput(event)
     this.resize(event)
   }
 
@@ -132,6 +132,7 @@ export class Textarea extends React.Component {
       label,
       length,
       name,
+      onChange,
       placeholder,
       readOnly,
       resizable,
@@ -150,7 +151,8 @@ export class Textarea extends React.Component {
           defaultValue={defaultValue}
           disabled={disabled}
           name={name}
-          onInput={this.handleChange}
+          onChange={onChange}
+          onInput={this.handleInput}
           placeholder={placeholder}
           readOnly={readOnly}
           rows={rows}

--- a/src/components/textfield/index.js
+++ b/src/components/textfield/index.js
@@ -116,6 +116,11 @@ export class Textarea extends React.Component {
     }
   }
 
+  handleChange = (event) => {
+    this.props.onChange(event)
+    this.resize(event)
+  }
+
   render () {
     const {
       autoFocus,
@@ -127,7 +132,6 @@ export class Textarea extends React.Component {
       label,
       length,
       name,
-      onChange,
       placeholder,
       readOnly,
       resizable,
@@ -146,8 +150,7 @@ export class Textarea extends React.Component {
           defaultValue={defaultValue}
           disabled={disabled}
           name={name}
-          onChange={onChange}
-          onInput={this.resize}
+          onInput={this.handleChange}
           placeholder={placeholder}
           readOnly={readOnly}
           rows={rows}

--- a/src/components/textfield/test/test.js
+++ b/src/components/textfield/test/test.js
@@ -113,7 +113,7 @@ describe('Textarea', () => {
     assert.equal(wrapper.find('textarea').node.rows, 2)
   })
 
-  it('should allow seting rows', () => {
+  it('should allow setting rows', () => {
     const wrapper = mount(<Textarea value={'foo'} rows={1} onChange={() => {}} />)
     assert.equal(wrapper.find('textarea').node.rows, 1)
   })


### PR DESCRIPTION
Hello!

This proposed PR makes Textarea component work with [Inferno](https://github.com/trueadm/inferno) - React-like library with a focus on performance. For performance reasons there are on synthetic events in Inferno, so this PR moves `onChange` handler to use native `oninput`. 

Tests show no regression.