### PR TITLE
stop using index for setting selected value

### DIFF
--- a/examples/src/selectRoute.js
+++ b/examples/src/selectRoute.js
@@ -5,26 +5,14 @@ import {Select} from '../../lib'
 export default class SelectRoute extends React.Component {
 
   state = {
-    selected: -1,
-    first: -1,
-    second: -1
+    first: '',
+    second: '',
+    third: ''
   }
 
-  onChangeFirst = (index) => {
+  onChange = (key, item) => {
     this.setState({
-      first: index
-    })
-  }
-
-  onChangeSecond = (index) => {
-    this.setState({
-      second: index
-    })
-  }
-
-  onChange = (index) => {
-    this.setState({
-      selected: index
+      [key]: item.value
     })
   }
 
@@ -34,43 +22,67 @@ export default class SelectRoute extends React.Component {
         <section>
           <h2>Select</h2>
           <Select
-            onChange={this.onChange}
-            items={['Blue', 'Red', 'Green']}
-            selectedIndex={this.state.selected}
+            onChange={(item) => this.onChange('first', item)}
+            options={[
+              {value: 'blue', label: 'Blue'},
+              {value: 'red', label: 'Red'},
+              {value: 'green', label: 'Green'}
+            ]}
+            value={this.state.first}
           />
         </section>
         <section>
           <h2>Select with scrolling</h2>
           <Select
-            onChange={this.onChange}
-            items={['Blue', 'Red', 'Green', 'Yellow', 'Orange', 'Black', 'White']}
-            selectedIndex={this.state.selected}
+            onChange={(item) => this.onChange('first', item)}
+            options={[
+              {value: 'blue', label: 'Blue'},
+              {value: 'red', label: 'Red'},
+              {value: 'green', label: 'Green'},
+              {value: 'yellow', label: 'Yellow'},
+              {value: 'orange', label: 'Orange'},
+              {value: 'black', label: 'Black'},
+              {value: 'white', label: 'White'}
+            ]}
+            value={this.state.first}
           />
         </section>
         <section>
           <h2>Select with label</h2>
           <Select
             label='Some label'
-            onChange={this.onChange}
-            items={['Blue', 'Red', 'Green']}
-            selectedIndex={this.state.selected}
+            onChange={(item) => this.onChange('first', item)}
+            options={[
+              {value: 'blue', label: 'Blue'},
+              {value: 'red', label: 'Red'},
+              {value: 'green', label: 'Green'}
+            ]}
+            value={this.state.first}
           />
         </section>
         <section>
           <h2>Disabled select</h2>
           <div style={{display: 'flex'}}>
             <Select
-              label='first'
-              onChange={this.onChangeFirst}
-              items={['One', 'Two', 'Three']}
-              selectedIndex={this.state.first}
+              label='second'
+              onChange={(item) => this.onChange('second', item)}
+              options={[
+                {value: 'one', label: 'One'},
+                {value: 'two', label: 'Two'},
+                {value: 'three', label: 'Three'}
+              ]}
+              value={this.state.second}
             />
             <Select
-              label='second'
-              onChange={this.onChangeSecond}
-              items={['Eleven', 'Twelve', 'Thirteen']}
-              selectedIndex={this.state.second}
-              disabled={this.state.first === -1}
+              label='third'
+              onChange={(item) => this.onChange('third', item)}
+              options={[
+                {value: 'eleven', label: 'Eleven'},
+                {value: 'twelve', label: 'Twelve'},
+                {value: 'thirteen', label: 'Thirteen'}
+              ]}
+              value={this.state.third}
+              disabled={this.state.second === ''}
             />
           </div>
         </section>

--- a/examples/src/tableRoute.js
+++ b/examples/src/tableRoute.js
@@ -51,7 +51,10 @@ export default class TableRoute extends React.Component {
     ],
     page: 1,
     rowsPerPageIndex: 0,
-    possibleRowsPerPage: [5, 10],
+    possibleRowsPerPage: [
+      {value: 0, label: 5},
+      {value: 1, label: 10}
+    ],
     comments: [
       'Add a comment',
       'Add a comment'
@@ -86,15 +89,15 @@ export default class TableRoute extends React.Component {
 
   onPaginateRight = () => {
     const page = this.state.page + 1
-    const rowsPerPage = this.state.possibleRowsPerPage[this.state.rowsPerPageIndex]
+    const rowsPerPage = this.state.possibleRowsPerPage[this.state.rowsPerPageIndex].label
     if (page * rowsPerPage <= this.state.data.length) {
       this.setState({page})
     }
   }
 
-  onChangeRowsPerPage = (index) => {
+  onChangeRowsPerPage = (item) => {
     this.setState({
-      rowsPerPageIndex: index
+      rowsPerPageIndex: item.value
     })
   }
 
@@ -123,7 +126,7 @@ export default class TableRoute extends React.Component {
   render () {
     const {head, simple} = this.state
     const {page} = this.state
-    const rowsPerPage = this.state.possibleRowsPerPage[this.state.rowsPerPageIndex]
+    const rowsPerPage = this.state.possibleRowsPerPage[this.state.rowsPerPageIndex].label
     const start = (page - 1) * rowsPerPage
     const end = start + rowsPerPage
     const xOfY = start + 1 + '-' + end + ' of ' + this.state.data.length

--- a/src/js/select/index.js
+++ b/src/js/select/index.js
@@ -18,16 +18,19 @@ export default class Select extends React.Component {
   static propTypes = {
     disabled: React.PropTypes.bool,
     label: React.PropTypes.string,
-    items: React.PropTypes.array,
+    options: React.PropTypes.array,
     placeholder: React.PropTypes.string,
-    onChange: React.PropTypes.func.isRequired,
-    selectedIndex: React.PropTypes.number
+    onChange: React.PropTypes.func.isRequired
   }
 
   static defaultProps = {
-    items: ['one', 'two', 'three'],
+    options: [
+      {value: 'one', label: 'one'},
+      {value: 'two', label: 'two'},
+      {value: 'three', label: 'three'}
+    ],
     placeholder: 'Placeholder',
-    selectedIndex: -1
+    value: ''
   }
 
   state = {
@@ -95,10 +98,11 @@ export default class Select extends React.Component {
   }
 
   render () {
-    const {selectedIndex, label, disabled} = this.props
+    const {label, disabled, options, value} = this.props
     const {open} = this.state
+    const selectedIndex = options.findIndex(option => option.value === value)
     const empty = selectedIndex === -1
-    const text = empty ? this.props.placeholder : this.props.items[selectedIndex]
+    const text = empty ? this.props.placeholder : this.props.options[selectedIndex].label
 
     return (
       <div className='Select' ref={(c) => { this.ref = c }}>
@@ -122,7 +126,7 @@ export default class Select extends React.Component {
                 opacity: style.opacity
               }}
               hasLabel={!!this.props.label}
-              items={this.props.items}
+              options={this.props.options}
               selectedIndex={selectedIndex}
               onClick={this.props.onChange}
               width={this.state.width}
@@ -143,7 +147,7 @@ class List extends React.Component {
 
   static propTypes = {
     hasLabel: React.PropTypes.bool,
-    items: React.PropTypes.array.isRequired,
+    options: React.PropTypes.array.isRequired,
     isInsideTable: React.PropTypes.bool,
     selectedIndex: React.PropTypes.number.isRequired,
     onClick: React.PropTypes.func.isRequired,
@@ -157,7 +161,7 @@ class List extends React.Component {
     const index = this.props.selectedIndex
 
     // create boolean helper variables
-    const scrollable = this.props.items.length > MAX_LIST_LENGTH
+    const scrollable = this.props.options.length > MAX_LIST_LENGTH
     const indexWithinFirstTwoItems = index < 2
 
     if (scrollable && !indexWithinFirstTwoItems) {
@@ -171,7 +175,7 @@ class List extends React.Component {
    */
   onClick = (index, event) => {
     event.preventDefault()
-    this.props.onClick(index)
+    this.props.onClick(this.props.options[index])
   }
 
   /**
@@ -189,7 +193,7 @@ class List extends React.Component {
       PADDING_TOP = 26
     }
 
-    const {items, selectedIndex} = this.props
+    const {options, selectedIndex} = this.props
 
     // handle list absolute position top
     const paddingTop = this.props.hasLabel ? PADDING_TOP_WITH_LABEL : PADDING_TOP
@@ -203,14 +207,14 @@ class List extends React.Component {
     }
 
     // handle scrollable lists with more than 5 list items
-    if (items.length > MAX_LIST_LENGTH) {
-      if (selectedIndex >= 2 && selectedIndex <= items.length - 3) {
+    if (options.length > MAX_LIST_LENGTH) {
+      if (selectedIndex >= 2 && selectedIndex <= options.length - 3) {
         // handle "center" items => always set to third position
         top = -1 * (paddingTop + (LIST_ITEM_HEIGHT * 2))
-      } else if (selectedIndex === items.length - 2) {
+      } else if (selectedIndex === options.length - 2) {
         // handle second last item
         top = -1 * (paddingTop + (LIST_ITEM_HEIGHT * 3))
-      } else if (selectedIndex === items.length - 1) {
+      } else if (selectedIndex === options.length - 1) {
         // handle last item
         top = -1 * (paddingTop + (LIST_ITEM_HEIGHT * 4))
       }
@@ -227,13 +231,13 @@ class List extends React.Component {
         className='Select-list'
         style={objectAssign(style, this.props.style)}
       >
-        {items.map((item, i) =>
+        {options.map((item, i) =>
           <li key={i} className='Select-listItem'>
             <a href
               className='Select-listItemLink'
               onClick={this.onClick.bind(this, i)}
             >
-              {item}
+              {item.label}
             </a>
           </li>
         )}

--- a/src/js/select/test/test.js
+++ b/src/js/select/test/test.js
@@ -33,8 +33,12 @@ describe('Select', () => {
     const wrapper = mount(
       <Select
         onChange={noop}
-        selectedIndex={2}
-        items={['Fox', 'Rabbit', 'Dog']}
+        value='dog'
+        options={[
+          {value: 'fox', label: 'Fox'},
+          {value: 'rabbit', label: 'Rabbit'},
+          {value: 'dog', label: 'Dog'}
+        ]}
       />
     )
     assert.equal(wrapper.find('.Select-body').text(), 'Dog')
@@ -65,7 +69,16 @@ describe('Select', () => {
 
   it('should close the list on click on an item', () => {
     const callback = () => {}
-    const wrapper = mount(<Select items={['Fox', 'Rabbit', 'Dog']} onChange={callback} />)
+    const wrapper = mount(
+      <Select
+        options={[
+          {value: 'fox', label: 'Fox'},
+          {value: 'rabbit', label: 'Rabbit'},
+          {value: 'dog', label: 'Dog'}
+        ]}
+        onChange={callback}
+      />
+    )
     // open list
     wrapper.find('.Select-body').simulate('click')
     assert.equal(wrapper.find('.Select-list').length, 1)
@@ -80,8 +93,17 @@ describe('Select', () => {
   it('should render the list directly above the selected item', () => {
     const wrapper = mount(
       <Select
-        selectedIndex={1}
-        items={['Fox', 'Rabbit', 'Dog', 'Horse', 'Mouse', 'Dragon', 'Unicorn', 'Wookiee']}
+        value='rabbit'
+        options={[
+          {value: 'fox', label: 'Fox'},
+          {value: 'rabbit', label: 'Rabbit'},
+          {value: 'dog', label: 'Dog'},
+          {value: 'horse', label: 'Horse'},
+          {value: 'mouse', label: 'mouse'},
+          {value: 'dragon', label: 'Dragon'},
+          {value: 'unicorn', label: 'Unicorn'},
+          {value: 'wookiee', label: 'Wookiee'}
+        ]}
         onChange={noop}
       />
     )
@@ -96,8 +118,18 @@ describe('Select', () => {
   it('should render a list item always in the middle of the list when list is too large', () => {
     const wrapper = mount(
       <Select
-        selectedIndex={6}
-        items={['Fox', 'Cat', 'Rabbit', 'Dog', 'Horse', 'Mouse', 'Dragon', 'Unicorn', 'Wookiee']}
+        value='dragon'
+        options={[
+          {value: 'fox', label: 'Fox'},
+          {value: 'cat', label: 'Cat'},
+          {value: 'rabbit', label: 'Rabbit'},
+          {value: 'dog', label: 'Dog'},
+          {value: 'horse', label: 'Horse'},
+          {value: 'mouse', label: 'mouse'},
+          {value: 'dragon', label: 'Dragon'},
+          {value: 'unicorn', label: 'Unicorn'},
+          {value: 'wookiee', label: 'Wookiee'}
+        ]}
         onChange={noop}
       />
     )
@@ -114,8 +146,18 @@ describe('Select', () => {
   it('should not show the second last item in the center of the list', () => {
     const wrapper = mount(
       <Select
-        selectedIndex={7}
-        items={['Fox', 'Cat', 'Rabbit', 'Dog', 'Horse', 'Mouse', 'Dragon', 'Unicorn', 'Wookiee']}
+        value='unicorn'
+        options={[
+          {value: 'fox', label: 'Fox'},
+          {value: 'cat', label: 'Cat'},
+          {value: 'rabbit', label: 'Rabbit'},
+          {value: 'dog', label: 'Dog'},
+          {value: 'horse', label: 'Horse'},
+          {value: 'mouse', label: 'mouse'},
+          {value: 'dragon', label: 'Dragon'},
+          {value: 'unicorn', label: 'Unicorn'},
+          {value: 'wookiee', label: 'Wookiee'}
+        ]}
         onChange={noop}
       />
     )
@@ -126,8 +168,18 @@ describe('Select', () => {
   it('should show the last item at the end of the list', () => {
     const wrapper = mount(
       <Select
-        selectedIndex={8}
-        items={['Fox', 'Cat', 'Rabbit', 'Dog', 'Horse', 'Mouse', 'Dragon', 'Unicorn', 'Wookiee']}
+        value='wookiee'
+        options={[
+          {value: 'fox', label: 'Fox'},
+          {value: 'cat', label: 'Cat'},
+          {value: 'rabbit', label: 'Rabbit'},
+          {value: 'dog', label: 'Dog'},
+          {value: 'horse', label: 'Horse'},
+          {value: 'mouse', label: 'mouse'},
+          {value: 'dragon', label: 'Dragon'},
+          {value: 'unicorn', label: 'Unicorn'},
+          {value: 'wookiee', label: 'Wookiee'}
+        ]}
         onChange={noop}
       />
     )
@@ -142,8 +194,18 @@ describe('Select', () => {
           <tr>
             <td>
               <Select
-                selectedIndex={8}
-                items={['Fox', 'Cat', 'Rabbit', 'Dog', 'Horse', 'Mouse', 'Dragon', 'Unicorn', 'Wookiee']}
+                value='wookiee'
+                options={[
+                  {value: 'fox', label: 'Fox'},
+                  {value: 'cat', label: 'Cat'},
+                  {value: 'rabbit', label: 'Rabbit'},
+                  {value: 'dog', label: 'Dog'},
+                  {value: 'horse', label: 'Horse'},
+                  {value: 'mouse', label: 'mouse'},
+                  {value: 'dragon', label: 'Dragon'},
+                  {value: 'unicorn', label: 'Unicorn'},
+                  {value: 'wookiee', label: 'Wookiee'}
+                ]}
                 onChange={noop}
               />
             </td>

--- a/src/js/table/index.js
+++ b/src/js/table/index.js
@@ -176,9 +176,9 @@ export const TableFooter = (props) => (
       {props.labelRowsPerPage}
     </span>
     <Select
-      items={props.possibleRowsPerPage}
+      options={props.possibleRowsPerPage}
       onChange={props.onChangeRowsPerPage}
-      selectedIndex={props.rowsPerPageIndex}
+      value={props.rowsPerPageIndex}
     />
     <span className='Table-footer-xOfY'>
       {props.labelXOfY}

--- a/src/js/table/test/test.js
+++ b/src/js/table/test/test.js
@@ -181,7 +181,12 @@ describe('Table', () => {
 
   it('should display the selected number of visible rows', () => {
     const footer = <TableFooter
-      possibleRowsPerPage={[5, 10, 20, 50]}
+      possibleRowsPerPage={[
+        {value: 0, label: 5},
+        {value: 1, label: 10},
+        {value: 2, label: 20},
+        {value: 3, label: 50}
+      ]}
       rowsPerPageIndex={3}
       onChangeRowsPerPage={() => {}}
     />


### PR DESCRIPTION
At the moment it is not possible to map an Array of values to be selected to an Array where a random index is `null` or `undefined`.

```js
const bitrates = [
  9.6,
  19.2,
  93.75,
  null,
  'Auto'
]
```

With my PR it could work like this

```js
<Select
  options=[
    {value: 0, label: 9.6},
    {value: 1, label: 19.2},
    {value: 2, label: 93.75},
    {value: 4, label: 'Auto'},
  ]
  value={4}
/>
```

Syntax (`options` and `value`) is take from [react-select](https://github.com/JedWatson/react-select).