### PR TITLE
fix checkbox alignment

### DIFF
--- a/src/js/checkbox/index.scss
+++ b/src/js/checkbox/index.scss
@@ -52,12 +52,14 @@
 
   &-icon {
     padding: 10px;
+    padding-left: 0;
     line-height: 0;
     outline: 0;
     fill: rgba(0, 0, 0, 0.54);
 
     @include medium {
       padding: 5px;
+      padding-left: 0;
     }
   }
 


### PR DESCRIPTION
closes #207 

reduces clickable / touchable size on the left. i think this is ok.
alternative would be to shift (negative margin, transform) the checkbox keeping the touchable area on the left.