### PR TITLE
Navigation: stop event propagation to underlying elements

### DIFF
--- a/src/js/navigation/index.js
+++ b/src/js/navigation/index.js
@@ -130,6 +130,9 @@ class Navigation extends React.Component {
     this.setState({
       visible: false
     })
+    if (event) {
+      event.preventDefault()
+    }
   }
 
   /**


### PR DESCRIPTION
close #289 
observed on iOS.