### PR TITLE
position underlying input inside of enclosing div

### DIFF
--- a/src/scss/checkbox.scss
+++ b/src/scss/checkbox.scss
@@ -12,8 +12,7 @@
 
   &-input {
     position: absolute;
-    top: 50%;
-    left: 10px;
+    left: 0;
     opacity: 0;
     z-index: -1;
 

--- a/src/scss/checkbox.scss
+++ b/src/scss/checkbox.scss
@@ -12,6 +12,8 @@
 
   &-input {
     position: absolute;
+    top: 50%;
+    left: 10px;
     opacity: 0;
     z-index: -1;
 


### PR DESCRIPTION
the underlying input was not positioned explicitly.
in firefox the input was __outside__ the enclosing div (causing tests to fail).