### PR TITLE
fix line height and use unitless value

### DIFF
--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -31,7 +31,7 @@ html {
 body {
   font-family: 'Roboto', sans-serif;
   font-size: 1em;
-  line-height: 1em;
+  line-height: 1.5;
   background: #f9f9f9;
   color: #333;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
before 

![screenshot from 2017-09-29 14-35-53](https://user-images.githubusercontent.com/1132354/31016070-878e1c08-a523-11e7-9cfc-fbb2ee4b8646.png)
![screenshot from 2017-09-29 14-42-31](https://user-images.githubusercontent.com/1132354/31016415-e513afd6-a524-11e7-92eb-50bc7fbf1a28.png)

after

![screenshot from 2017-09-29 14-36-33](https://user-images.githubusercontent.com/1132354/31016097-9ccd253c-a523-11e7-999f-c472e5370bd8.png)
![screenshot from 2017-09-29 14-44-56](https://user-images.githubusercontent.com/1132354/31016427-e9d6c94a-a524-11e7-9dfb-7acdea21ac07.png)

Have a look at the lower part of the <kbd>g</kbd>.
It also fixes the box when highlighting DOM nodes within the inspector. It is the same value bootstrap uses https://github.com/twbs/bootstrap/blob/502ac7ee4d13669e644b9181f1e014ce0ea1f089/dist/css/bootstrap.css#L93.
