### PR TITLE
fix subtitle wrap and overflow

### DIFF
--- a/src/js/header/index.js
+++ b/src/js/header/index.js
@@ -35,7 +35,7 @@ export default class Header extends React.Component {
     }, className)
     return (
       <header className={klass}>
-        <div className='mdc-Header-block'>
+        <div className='mdc-Header-left'>
           <span className='mdc-Header-title'>
             {title}
           </span>
@@ -43,7 +43,7 @@ export default class Header extends React.Component {
             subtitle &&
             <span className='mdc-Header-subtitle'>
               <ChevronRight className='mdc-Header-chevron' />
-              {subtitle}
+              <div className='mdc-Header-subtitle-text'>{subtitle}</div>
             </span>
           }
         </div>

--- a/src/scss/header.scss
+++ b/src/scss/header.scss
@@ -37,6 +37,12 @@
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.26);
 }
 
+.mdc-Header-left {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+}
+
 .mdc-Header-block {
   display: flex;
   align-items: center;
@@ -70,9 +76,16 @@
   font-size: 20px;
   display: flex;
   align-items: center;
+  min-width: 0;
 
   @include medium {
     font-size: 24px;
     margin-left: 0;
   }
+}
+
+.mdc-Header-subtitle-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
before
![screenshot from 2017-10-09 13-06-19](https://user-images.githubusercontent.com/1132354/31335511-33b72cdc-acf3-11e7-872a-d8041c4c20bd.png)

after
![screenshot from 2017-10-09 13-04-06](https://user-images.githubusercontent.com/1132354/31335510-3391d766-acf3-11e7-88b7-9c7ceef2bd80.png)

was a bit tricky because of flex and `text-overflow: ellipsis`. https://css-tricks.com/flexbox-truncated-text/