### PR TITLE
improve style for read only textfield

### DIFF
--- a/src/scss/textfield.scss
+++ b/src/scss/textfield.scss
@@ -79,6 +79,15 @@ $error-color: rgb(244, 67, 54);
   margin-bottom: 8px;
 }
 
+.mdc-Textfield-input[readonly] {
+  color: rgba(0, 0, 0, 0.38);
+  border-bottom: 1px dashed rgba(0, 0, 0, 0.42);
+}
+
+.mdc-Textfield-input[readonly] ~ .mdc-Textfield-label {
+  color: rgba(0, 0, 0, 0.38);
+}
+
 .mdc-Textfield-input:not([readonly]):focus {
   border-bottom-color: $blue-dark;
   box-shadow: 0 1px 0 0 $blue-dark;


### PR DESCRIPTION
Currently our `readOnly` textfield looks like a normal textfield. This can be very confusing for the user. I've used the `disabled` spec and applied it to our `readOnly` textfields.

https://material.io/guidelines/components/text-fields.html#text-fields-states