### PR TITLE
make chip css selectors more precise

### DIFF
--- a/src/js/chip/index.js
+++ b/src/js/chip/index.js
@@ -180,7 +180,7 @@ const Element = ({
               onDelete(event.currentTarget.parentElement, index)
             }}
           >
-            <Cancel style={{width: 22, height: 22, display: 'block'}} />
+            <Cancel className='mdc-Chip-delete-icon' />
           </button>
         )
         : null

--- a/src/scss/chip.scss
+++ b/src/scss/chip.scss
@@ -41,12 +41,15 @@
   margin: 0 4px;
 }
 
-.mdc-Chip svg {
+.mdc-Chip-delete-icon {
+  width: 22px;
+  height: 22px;
+  display: block;
   fill: rgba(0, 0, 0, 0.26);
 }
 
-.mdc-Chip:focus svg,
-.mdc-Chip:hover svg {
+.mdc-Chip:focus .mdc-Chip-delete-icon,
+.mdc-Chip:hover .mdc-Chip-delete-icon {
   fill: #fff;
 }
 


### PR DESCRIPTION
The old style would also apply to custom SVGs inside our Chips. That's not what we want.

In our application we'd get incorrect styles when an LED (svg icon from material design) is inside the Chip component.