### PR TITLE
Header fix: attach to touchmove event to trigger this.onScroll

### DIFF
--- a/src/js/header/index.js
+++ b/src/js/header/index.js
@@ -17,12 +17,14 @@ export default class Header extends React.Component {
   componentDidMount () {
     if (this.props.shadowOnScroll) {
       window.addEventListener('scroll', this.onScroll)
+      window.addEventListener('touchmove', this.onScroll)
     }
   }
 
   componentWillUnmount () {
     if (this.props.shadowOnScroll) {
       window.removeEventListener('scroll', this.onScroll)
+      window.removeEventListener('touchmove', this.onScroll)
     }
   }
 


### PR DESCRIPTION
immediately shows shadow when scrolling on mobile. Previous impl added shadow after touchend.

https://stackoverflow.com/questions/2863547/javascript-scroll-event-for-iphone-ipad

tested on iOS